### PR TITLE
Fixed new error with section spacing once merged

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -366,7 +366,7 @@ footer p {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin: 5% 5% 5% 5%;
+  margin: 12% 5% 5% 5%;
   width: 90%;
   height: 100%;
   background-color: white;

--- a/less/home-page.less
+++ b/less/home-page.less
@@ -51,7 +51,7 @@
 
 .section1-container {
   .columns(center, center);
-  margin: 5% 5% 5% 5%;
+  margin: 12% 5% 5% 5%;
   width: 90%;
   height: 100%;
   background-color: white;


### PR DESCRIPTION
Section 1 is overlapping the header background image once merging to master, but not on my local machine. Have fixed this with added margin (let's hope).